### PR TITLE
Resize login and register panels for mobile, fix sticky nav items

### DIFF
--- a/client/src/components/LoginPanel.module.css
+++ b/client/src/components/LoginPanel.module.css
@@ -55,3 +55,10 @@
 .sign_up_highlight:hover {
   text-decoration: underline;
 }
+
+@media (max-width: 40.625rem) {
+  .container {
+    width: 18rem;
+    margin-left: -9rem;
+  }
+}

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -34,6 +34,16 @@ class Navbar extends Component {
           {this.props.isLoggedIn ? (
             <>
               <li>
+                <button
+                  onClick={this.toggleNavDropdown}
+                  className={classNames([styles.hamburger], [styles.stick_top_right], {
+                    [styles.hamburger_Active]: this.state.isShowingNavDropdown
+                  })}
+                >
+                  &#9776;
+                </button>
+              </li>
+              <li>
                 <NavLink
                   exact
                   to="/"
@@ -80,16 +90,6 @@ class Navbar extends Component {
             </li>
           )}
         </ul>
-        {this.props.isLoggedIn && (
-          <button
-            onClick={this.toggleNavDropdown}
-            className={classNames([styles.hamburger], [styles.stick_top_right], {
-              [styles.hamburger_Active]: this.state.isShowingNavDropdown
-            })}
-          >
-            &#9776;
-          </button>
-        )}
       </nav>
     );
   }

--- a/client/src/components/Navbar.module.css
+++ b/client/src/components/Navbar.module.css
@@ -48,31 +48,36 @@
     text-decoration: none;
     color: #777;
     cursor: pointer;
-    display: block;
     border: none;
     background-color: white;
     font-size: medium;
   }
+
   .hamburger_Active {
     background-color: #e9e9e9;
   }
+
   .hide {
     display: none;
   }
+
   .nav_list {
     padding-left: 0;
     padding-right: 0;
     flex-direction: column;
   }
+
   .nav_list__header {
     display: block;
   }
+
   .display_left {
     margin-right: auto;
     width: 100%;
   }
+  
   .stick_top_right {
-    position: fixed;
+    position: absolute;
     right: 0;
     top: 0;
   }

--- a/client/src/components/RegisterPanel.module.css
+++ b/client/src/components/RegisterPanel.module.css
@@ -55,3 +55,10 @@
 .sign_up_highlight:hover {
   text-decoration: underline;
 }
+
+@media (max-width: 40.625rem) {
+  .container {
+    width: 18rem;
+    margin-left: -9rem;
+  }
+}


### PR DESCRIPTION
- Made the login and register panels smaller on mobile.
- There was an issue where the Login and hamburger buttons would stay fixed in the same position even when you scrolled (on mobile), so I changed the positioning from fixed to absolute.
- Got rid of a redundant display: block.
- Moved the hamburger button into the existing block of nav items that render when the user is logged in.